### PR TITLE
[Fix/955] Fixed Border Styling For User Profiles on Firefox Browsers

### DIFF
--- a/src/app/user-pages/profile/profile.component.css
+++ b/src/app/user-pages/profile/profile.component.css
@@ -37,7 +37,7 @@ aside > img {
 .username-display {
     margin-top: 30px;
     border-bottom: 2px solid gray;
-    width: -webkit-fill-available;
+    width: 100%;
     overflow-wrap: anywhere;
 }
 


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/Butterstroke/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes an issue where the bottom border did not extend the full length of the screen width on Firefox browsers.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the width property from `-webkit-fill-availible` to `100%`.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#955