### PR TITLE
[Fix/936] Fixed Issue with Disappearing Titles

### DIFF
--- a/src/app/search-bar/search-bar.component.html
+++ b/src/app/search-bar/search-bar.component.html
@@ -22,7 +22,7 @@
                         <span *ngIf="hoveredRow == null">{{element.title.substring(0, 57)}}...</span>
                         <span *ngIf="hoveredRow && element.isbn !== hoveredRow.isbn">{{element.title.substring(0, 57)}}...</span>
                     </strong>
-                    <strong *ngIf="element.title.length < 57">{{element.title}}</strong>
+                    <strong *ngIf="element.title.length < 57 || element.title.length === 57">{{element.title}}</strong>
                 </p>
                 <br>
                 <p class="search-item-format"><em>({{element.format_name | bookFormat}}, {{element.book_type_name | titlecase}})</em></p>


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/AurelicButter/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixes an issue with the search bar where certain titles would not appear in the dropdown.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the if statements around truncating the title as there was a condition for any title above 57 characters and any title below 57 characters. The titles used as examples for replication were all exactly 57 characters and thus did not meet any if condition. Now if the title is exactly 57 characters long, the title will appear as if the title had less than 57 characters.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->
Internal#936