### PR TITLE
[Fix/960] Updated Key in Book Correction Submission

### DIFF
--- a/src/app/pages/book-correction-form/book-correction-form.component.ts
+++ b/src/app/pages/book-correction-form/book-correction-form.component.ts
@@ -113,8 +113,8 @@ export class BookCorrectionFormComponent implements OnInit {
 			if (this.correction.description !== this.existingData.description) {
 				forSubmission.description = this.correction.description;
 			}
-			if (this.correction.cover_url) {
-				forSubmission.cover_url = this.correction.cover_url;
+			if (this.correction.cover_image) {
+				forSubmission.cover_image = this.correction.cover_image;
 			}
 			if (this.correction.release_date !== this.existingData.release_date.split("T")[0]) {
 				forSubmission.release_date = this.correction.release_date;


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/AurelicButter/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixed an issue where the cover URL was not being saved on correction submission.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

Updated the key from cover_url to cover_image per API changes and requirements.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->
Internal#960