### PR TITLE
[Fix/961] Fixed Issue With New Release Dates Not Displaying on Correction Form

### DIFF
--- a/src/app/admin-pages/book-correction/book-correction.component.css
+++ b/src/app/admin-pages/book-correction/book-correction.component.css
@@ -13,6 +13,10 @@
     color: inherit;
 }
 
+.center-text {
+    text-align: center;
+}
+
 .correction-input, .old-data-display {
     height: 40px;
 }

--- a/src/app/admin-pages/book-correction/book-correction.component.html
+++ b/src/app/admin-pages/book-correction/book-correction.component.html
@@ -72,7 +72,7 @@
             <div class="correction-comparison">
                 <div class="correction-field">
                     <label class="correction-label-inner">New</label>
-                    <input class="form-control correction-input" type="date" name="releaseDate" [(ngModel)]="correctionData.release_date" disabled>
+                    <input class="form-control correction-input center-text" type="date" name="releaseDate" [value]="releaseDateDisplay" [(ngModel)]="releaseDateDisplay" disabled>
                 </div>
                 <div class="correction-field" *ngIf="bookData">
                     <label class="correction-label-inner">Current</label>

--- a/src/app/admin-pages/book-correction/book-correction.component.ts
+++ b/src/app/admin-pages/book-correction/book-correction.component.ts
@@ -32,6 +32,7 @@ export class BookCorrectionComponent implements OnInit {
 	formats: BookFormat[];
 	publishers: ImprintData[];
 	correctionDescription = new FormControl("");
+	releaseDateDisplay: string;
 
 	constructor(
 		private service: MynewormAPIService,
@@ -59,6 +60,12 @@ export class BookCorrectionComponent implements OnInit {
 
 				if (this.correctionData.description !== undefined) {
 					this.correctionDescription.setValue(this.correctionData.description);
+				}
+
+				if (this.correctionData.release_date !== undefined) {
+					this.releaseDateDisplay = moment(this.correctionData.release_date.split("T")[0]).format(
+						"YYYY-MM-DD"
+					);
 				}
 
 				this.service.getUserByID(correction.submitter_id.toString()).subscribe((user) => {

--- a/src/app/models/BookCorrection.ts
+++ b/src/app/models/BookCorrection.ts
@@ -6,7 +6,7 @@ export interface BookCorrectionEntry {
 	cover_image?: string;
 	format_name?: string;
 	book_type?: string;
-	release_date?: Date;
+	release_date?: string;
 	publisher_id?: number;
 	series_id?: number;
 	comment?: string;


### PR DESCRIPTION
<!-- 
    Thank you for contributing! 
    If you have not already, please review the contribution guidelines before submitting:
    https://github.com/AurelicButter/Myneworm/tree/master/.github/CONTRIBUTING.md
-->

## What Does This Do?
<!--
    Give a generalized summary of the changes made.
    IE: "Moved the Selector Button Over for Desktop Users"
-->

Fixed an issue where the new release dates were not displayed on the correction form to the approver for verification.

## How is it Done?
<!--
    Explain what you've done to get the results and fixes you made. More descriptive PRs
    are more likely to be accepted but do not provide a timeline of events or step by step instructions.

    IE:
    """
    Since there are reports of CSS overlap with the selector button, I've updated the CSS file for the component.
    I've verified that my changes worked for Chromium and Firefox browsers but have not tested the changes on mobile.
    """
-->

This was a graphical issue so no back-end updates required.

The fix now sets the default value of the input field with a formatted `YYYY-MM-DD` string instead of attempting to infer it from ngModel.

## Related Tickets and Issues
<!-- 
    List all possible tickets and issues the PR targets
    For instance, if a fix targets an internal ticket 000 and GitHub issue 000,
    the user would write "Internal#000 and #000".

    If there is no internal ticket or GitHub issue, the user does not have to
    mention that.
-->

Internal#961